### PR TITLE
Fix return type in version utility

### DIFF
--- a/src/WebDriverManager.cls
+++ b/src/WebDriverManager.cls
@@ -1047,7 +1047,7 @@ Private Function selectVersionPart(ByVal versionString As String, ByVal partNumb
     selectVersionPart = verParts(partNumber - 1)
 End Function
 
-Private Function countVersionParts(ByVal versionString As String) As String
+Private Function countVersionParts(ByVal versionString As String) As Long
     countVersionParts = UBound(Split(versionString, ".")) + 1
 End Function
 


### PR DESCRIPTION
## Summary
- fix function return type in `WebDriverManager.cls`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408493b0d08329a88f0a24e244331d